### PR TITLE
Singleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 [![npm version][2]][3] [![build status][4]][5]
 [![downloads][8]][9] [![js-standard-style][10]][11]
 
-Listen for performance timeline events and clears them after usage.
+Listen for performance timeline events and clears them after usage. Returns a
+singleton.
 
 ## Usage
 ```js
@@ -15,7 +16,9 @@ onPerformance(function (entry) {
 
 ## API
 ### `stop = onPerformance(callback(entry))`
-Listen for performance events.
+Listen for performance events. Returns a singleton (e.g. multiple calls to this
+method are registered on the same listener). If multiple instances are created
+during the first tick, all initial events will be played back to all instances.
 
 ### `stop()`
 Stop the observer.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var onIdle = require('on-idle')
+var scheduler = require('nanoscheduler')()
 var assert = require('assert')
 
 module.exports = onPerformance
@@ -21,7 +21,7 @@ function onPerformance (cb) {
   })
 
   window.performance.getEntries().forEach(function (entry) {
-    onIdle(function () {
+    scheduler.push(function () {
       cb(entry)
       clear(entry)
     })
@@ -29,7 +29,7 @@ function onPerformance (cb) {
 
   function handler (list) {
     list.getEntries().forEach(function (entry) {
-      onIdle(function () {
+      scheduler.push(function () {
         cb(entry)
         clear(entry)
       })

--- a/index.js
+++ b/index.js
@@ -1,5 +1,13 @@
-var scheduler = require('nanoscheduler')()
+var onIdle = require('on-idle')
 var assert = require('assert')
+
+var entryTypes = [
+  'frame',
+  'measure',
+  'navigation',
+  'resource',
+  'longtask'
+]
 
 module.exports = onPerformance
 
@@ -9,48 +17,34 @@ function onPerformance (cb) {
   var PerformanceObserver = typeof window !== 'undefined' && window.PerformanceObserver
   if (!PerformanceObserver) return
 
-  var observer = new PerformanceObserver(handler)
-  observer.observe({
-    entryTypes: [
-      'frame',      // not implemented yet in any browser
-      'measure',
-      'navigation',
-      'resource',
-      'longtask'
-    ]
-  })
+  // Enable singleton.
+  if (window._onperformance) return window._onperformance.push(cb)
 
-  window.performance.getEntries().forEach(function (entry) {
-    scheduler.push(function () {
-      cb(entry)
-      clear(entry)
-    })
-  })
+  window._onperformance = [cb]
+  var observer = new PerformanceObserver(parseEntries)
+  setTimeout(function () {
+    parseEntries(window.performance)
+    observer.observe({ entryTypes: entryTypes })
+  }, 0)
+  return observer.disconnect.bind(observer)
 
-  function handler (list) {
+  function parseEntries (list) {
     list.getEntries().forEach(function (entry) {
-      scheduler.push(function () {
-        cb(entry)
+      onIdle(function () {
+        window._onperformance.forEach(function (cb) {
+          cb(entry)
+        })
         clear(entry)
       })
     })
   }
-
-  // Workaround to prevent the observer instance from being garbage collected
-  // https://twitter.com/choojs/status/876098840495091713
-  window['obs' + window.performance.now()] = observer
-
-  return observer.disconnect.bind(observer)
 
   // Navigation, longtask and frame don't have a clear method (yet)
   // Resource timings can only be cleared in bulk
   // see: https://developer.mozilla.org/en-US/docs/Web/API/Performance/clearMeasures
   function clear (entry) {
     var type = entry.entryType
-    if (type === 'measure') {
-      window.performance.clearMeasures(entry.name)
-    } else if (type === 'resource') {
-      window.performance.clearResourceTimings()
-    }
+    if (type === 'measure') window.performance.clearMeasures(entry.name)
+    else if (type === 'resource') window.performance.clearResourceTimings()
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
     "start": "bankai start test.js",
     "test": "standard && npm run deps && browserify test | tape-run"
   },
+  "browser": {
+    "assert": "nanoassert"
+  },
   "dependencies": {
+    "nanoassert": "^1.1.0",
     "nanoscheduler": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "standard && npm run deps && browserify test | tape-run"
   },
   "dependencies": {
-    "on-idle": "^3.0.0"
+    "nanoscheduler": "^1.0.0"
   },
   "devDependencies": {
     "bankai": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "repository": "choojs/on-performance",
   "version": "1.0.1",
   "scripts": {
-    "deps": "dependency-check . && dependency-check . --extra --no-dev",
+    "deps": "dependency-check . && dependency-check . --extra --no-dev -i nanoassert",
     "start": "bankai start test.js",
     "test": "standard && npm run deps && browserify test | tape-run"
   },


### PR DESCRIPTION
Convert `on-performance` to a singleton, so multiple instances can receive all events, without losing any of the existing data.

There's no good ways to do this, but I think using a singleton will be the most convenient to use / least prone to errors. Also not a fan of the "for all listeners to receive all events, they must be attached in the same tick" — but think in practice it'll be good enough. Wellllp, hope this good!

__edit:__ depends on https://github.com/choojs/on-performance/pull/3 to be merged first.