### PR TITLE
get on-performance to work in node env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 node_js:
-- "4"
-- "5"
-- "6"
-- "7"
+- "8.5"
+- "9"
 sudo: false
 language: node_js
 script: "npm run test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 node_js:
-- "8.5"
+- "7"
+- "8"
 - "9"
 sudo: false
 language: node_js

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![downloads][8]][9] [![js-standard-style][10]][11]
 
 Listen for performance timeline events and clears them after usage. Returns a
-singleton.
+singleton. Can be used in both node and browser environments.
 
 ## Usage
 ```js

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,58 @@
+var scheduler = require('nanoscheduler')()
+var assert = require('assert')
+
+var entryTypes = [
+  'frame',
+  'measure',
+  'navigation',
+  'resource',
+  'longtask'
+]
+
+module.exports = onPerformance
+
+function onPerformance (cb) {
+  assert.equal(typeof cb, 'function', 'on-performance: cb should be type function')
+
+  var PerformanceObserver = typeof window !== 'undefined' && window.PerformanceObserver
+  if (!PerformanceObserver) return
+
+  // Enable singleton.
+  if (window._onperformance) {
+    window._onperformance.push(cb)
+    return stop
+  }
+
+  window._onperformance = [cb]
+  var observer = new PerformanceObserver(parseEntries)
+  setTimeout(function () {
+    parseEntries(window.performance)
+    observer.observe({ entryTypes: entryTypes })
+  }, 0)
+
+  return stop
+
+  function stop () {
+    window._onperformance.splice(window._onperformance.indexOf(cb), 1)
+  }
+
+  function parseEntries (list) {
+    list.getEntries().forEach(function (entry) {
+      scheduler.push(function () {
+        clear(entry)
+        window._onperformance.forEach(function (cb) {
+          cb(entry)
+        })
+      })
+    })
+  }
+
+  // Navigation, longtask and frame don't have a clear method (yet)
+  // Resource timings can only be cleared in bulk
+  // see: https://developer.mozilla.org/en-US/docs/Web/API/Performance/clearMeasures
+  function clear (entry) {
+    var type = entry.entryType
+    if (type === 'measure') window.performance.clearMeasures(entry.name)
+    else if (type === 'resource') window.performance.clearResourceTimings()
+  }
+}

--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ var entryTypes = [
 module.exports = onPerformance
 
 function onPerformance (cb) {
+  if (typeof window !== 'undefined') return require('./browser.js')(cb) // electron support
+
   assert.equal(typeof cb, 'function', 'on-performance: cb should be type function')
 
   var PerformanceObserver

--- a/index.js
+++ b/index.js
@@ -1,12 +1,11 @@
-var scheduler = require('nanoscheduler')()
 var assert = require('assert')
 
 var entryTypes = [
-  'frame',
+  'node',
+  'mark',
   'measure',
-  'navigation',
-  'resource',
-  'longtask'
+  'gc',
+  'function'
 ]
 
 module.exports = onPerformance
@@ -14,45 +13,47 @@ module.exports = onPerformance
 function onPerformance (cb) {
   assert.equal(typeof cb, 'function', 'on-performance: cb should be type function')
 
-  var PerformanceObserver = typeof window !== 'undefined' && window.PerformanceObserver
-  if (!PerformanceObserver) return
+  var PerformanceObserver
+  var performance
+  try {
+    PerformanceObserver = require('perf_hooks').PerformanceObserver
+    performance = require('perf_hooks').performance
+  } catch (e) {
+    return cb(new Error('on-performance: PerformanceObserver is unavailable. Use Node v8.5.0 or higher.'))
+  }
 
   // Enable singleton.
-  if (window._onperformance) {
-    window._onperformance.push(cb)
+  if (global._onperformance) {
+    global._onperformance.push(cb)
     return stop
   }
 
-  window._onperformance = [cb]
+  global._onperformance = [cb]
   var observer = new PerformanceObserver(parseEntries)
   setTimeout(function () {
-    parseEntries(window.performance)
+    parseEntries(performance)
     observer.observe({ entryTypes: entryTypes })
   }, 0)
 
   return stop
 
   function stop () {
-    window._onperformance.splice(window._onperformance.indexOf(cb), 1)
+    global._onperformance.splice(global._onperformance.indexOf(cb), 1)
   }
 
   function parseEntries (list) {
     list.getEntries().forEach(function (entry) {
-      scheduler.push(function () {
-        clear(entry)
-        window._onperformance.forEach(function (cb) {
-          cb(entry)
-        })
+      clear(entry)
+      global._onperformance.forEach(function (cb) {
+        cb(entry)
       })
     })
   }
 
-  // Navigation, longtask and frame don't have a clear method (yet)
-  // Resource timings can only be cleared in bulk
-  // see: https://developer.mozilla.org/en-US/docs/Web/API/Performance/clearMeasures
   function clear (entry) {
     var type = entry.entryType
-    if (type === 'measure') window.performance.clearMeasures(entry.name)
-    else if (type === 'resource') window.performance.clearResourceTimings()
+    if (type === 'measure') performance.clearMeasures(entry.name)
+    else if (type === 'mark') performance.clearMarks(entry.name)
+    else if (type === 'function') performance.clearFunctions(entry.name)
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,13 +2,12 @@
   "name": "on-performance",
   "description": "Listen for performance timeline events",
   "repository": "choojs/on-performance",
-  "browser": "browser.js",
   "main": "index.js",
+  "browser": "browser.js",
   "version": "1.1.0",
   "scripts": {
-    "deps": "dependency-check . && dependency-check . --extra --no-dev -i nanoassert",
     "start": "bankai start test.js",
-    "test": "standard && npm run deps && browserify test | tape-run"
+    "test": "standard && browserify test | tape-run"
   },
   "browser": {
     "assert": "nanoassert"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "on-performance",
   "description": "Listen for performance timeline events",
   "repository": "choojs/on-performance",
+  "browser": "browser.js",
+  "main": "index.js",
   "version": "1.1.0",
   "scripts": {
     "deps": "dependency-check . && dependency-check . --extra --no-dev -i nanoassert",

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 var nanotiming = require('nanotiming')
 var tape = require('tape')
 
-var onPerformance = require('./')
+var onPerformance = require('./browser')
 
 tape('should flush already buffered events', function (assert) {
   var startLength = window.performance.getEntries().length


### PR DESCRIPTION
This allows `on-performance` to work in node > 8.5.0 (those with performance observer support).

Creates a new `browser.js` file for browserify. The node version of things lives in `index.js`. The two are reflected in `package.json`.

Thank you ^_____^